### PR TITLE
 403 status code is returned for permission not allowed

### DIFF
--- a/tests/tenant/create.test.ts
+++ b/tests/tenant/create.test.ts
@@ -96,6 +96,19 @@ describe("POST /api/tenant/create", () => {
             expect(tenants[0].name).toBe(tenantData.name);
             expect(tenants[0].address).toBe(tenantData.address);
         });
+
+        it("should return 403 status code if permission not allowed!", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.MANAGER,
+            });
+
+            const tenantResponse = await request(app)
+                .post("/api/tenant/create")
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(tenantResponse.statusCode).toBe(403);
+        });
     });
 
     describe("Some missing fields", () => {


### PR DESCRIPTION
## Description
This pull request adds a Jest test case to ensure that a 403 status code is returned for permission not allowed, except for admin users.

## Changes Made
- Added a Jest test case in `tests/create.test.ts` to check for a 403 status code when permission is not allowed for non-admin users.

## Testing
- Ran the test suite locally to verify that the new test case passes.

## Checklist

-  ✅ Tests added and pass
-  ✅ Follows the coding style of the project
-  ✅ Commit messages are descriptive
