### PR TITLE
Get all tenants endpoint

### DIFF
--- a/src/controllers/TenantController.ts
+++ b/src/controllers/TenantController.ts
@@ -40,4 +40,13 @@ export default class TenantController {
             return next(error);
         }
     }
+
+    async getAll(req: Request, res: Response, next: NextFunction) {
+        try {
+            const tenants = await this.tenantService.getAll();
+            return res.json({ tenants });
+        } catch (error) {
+            return next(error);
+        }
+    }
 }

--- a/src/routes/tenant.ts
+++ b/src/routes/tenant.ts
@@ -40,4 +40,11 @@ router.delete(
         tenantController.delete(req, res, next) as unknown as RequestHandler,
 );
 
+router.get(
+    "/",
+    [accessTokenMiddleware, canAccess([Role.ADMIN])],
+    (req: Request, res: Response, next: NextFunction) =>
+        tenantController.getAll(req, res, next) as unknown as RequestHandler,
+);
+
 export default router;

--- a/src/services/TenantService.ts
+++ b/src/services/TenantService.ts
@@ -11,4 +11,8 @@ export default class TenantService {
     async deleteById(tenantId: number) {
         return await this.tenantRepository.delete({ id: tenantId });
     }
+
+    async getAll() {
+        return await this.tenantRepository.find();
+    }
 }

--- a/tests/tenant/getAll.test.ts
+++ b/tests/tenant/getAll.test.ts
@@ -1,0 +1,94 @@
+import request from "supertest";
+import app from "../../src/app";
+import { DataSource } from "typeorm";
+import { AppDataSource } from "../../src/config";
+import createJwtMock from "mock-jwks";
+import { Role } from "../../src/constants";
+
+describe("POST /api/tenant/create", () => {
+    let connection: DataSource;
+    let jwt: ReturnType<typeof createJwtMock>;
+
+    beforeAll(async () => {
+        jwt = createJwtMock("http://localhost:5000");
+        connection = await AppDataSource.initialize();
+    });
+
+    beforeEach(async () => {
+        jwt.start();
+        await connection.dropDatabase();
+        await connection.synchronize();
+    });
+
+    afterEach(() => {
+        jwt.stop();
+    });
+
+    const tenantData = {
+        name: "Fudo Restaurant",
+        address: "Near Sivaji Nagar, Barshi",
+    };
+
+    describe("Given all fields", () => {
+        it("should returns the 200 status code", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.ADMIN,
+            });
+
+            const getTenantResponse = await request(app)
+                .get("/api/tenant")
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(getTenantResponse.statusCode).toBe(200);
+        });
+
+        it("should returns json data", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.ADMIN,
+            });
+
+            const getTenantResponse = await request(app)
+                .get("/api/tenant")
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(
+                (getTenantResponse.headers as Record<string, string>)[
+                    "content-type"
+                ],
+            ).toEqual(expect.stringContaining("json"));
+        });
+
+        it("should return all tenants", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.ADMIN,
+            });
+
+            await request(app)
+                .post("/api/tenant/create")
+                .send(tenantData)
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            const getTenantResponse = await request(app)
+                .get("/api/tenant")
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(getTenantResponse.body.tenants).toHaveLength(1);
+        });
+
+        it("should return 403 status code if permission not allowed!", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.MANAGER,
+            });
+
+            const getTenantResponse = await request(app)
+                .get("/api/tenant")
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(getTenantResponse.statusCode).toBe(403);
+        });
+    });
+});


### PR DESCRIPTION
## Description
This pull request introduces a new endpoint to retrieve a list of all tenants via a `GET` request. The endpoint is located at `api/tenant`.

## Changes Made
- Added a new route for the `GET /api/tenant` endpoint.

## Response 

```json
[
  {
    "id" : 1,
    "name" : "Tenant 1",
    "address" : "address 1",
    "rating" : 7
  },
  {
    "id": 2,
    "name": "Tenant 2",
    "address" : "address 1",
     "rating" : 7
  },
  // ... more tenants
]
```

## Testing
✅ Manually tested the new endpoint to ensure it returns the expected list of tenants.
✅ New endpoint added and tested
✅ Follows the coding style and conventions of the project
✅ Commit messages are clear and descriptive