### PR TITLE
Get tenant by id endpoint

### DIFF
--- a/src/controllers/TenantController.ts
+++ b/src/controllers/TenantController.ts
@@ -49,4 +49,19 @@ export default class TenantController {
             return next(error);
         }
     }
+
+    async getOne(req: Request, res: Response, next: NextFunction) {
+        const tenantId = req.params.id;
+        if (isNaN(Number(tenantId))) {
+            return next(createHttpError(400, "Invalid url param!"));
+        }
+
+        try {
+            const tenant = await this.tenantService.getById(Number(tenantId));
+            if (!tenant) return res.json({ tenant: null });
+            return res.json({ tenant: new TenantDto(tenant) });
+        } catch (error) {
+            return next(error);
+        }
+    }
 }

--- a/src/routes/tenant.ts
+++ b/src/routes/tenant.ts
@@ -47,4 +47,11 @@ router.get(
         tenantController.getAll(req, res, next) as unknown as RequestHandler,
 );
 
+router.get(
+    "/:id",
+    [accessTokenMiddleware, canAccess([Role.ADMIN])],
+    (req: Request, res: Response, next: NextFunction) =>
+        tenantController.getOne(req, res, next) as unknown as RequestHandler,
+);
+
 export default router;

--- a/src/services/TenantService.ts
+++ b/src/services/TenantService.ts
@@ -15,4 +15,8 @@ export default class TenantService {
     async getAll() {
         return await this.tenantRepository.find();
     }
+
+    async getById(tenantId: number) {
+        return await this.tenantRepository.findOne({ where: { id: tenantId } });
+    }
 }

--- a/tests/tenant/getOne.test.ts
+++ b/tests/tenant/getOne.test.ts
@@ -1,0 +1,154 @@
+import request from "supertest";
+import app from "../../src/app";
+import { DataSource } from "typeorm";
+import { AppDataSource } from "../../src/config";
+import createJwtMock from "mock-jwks";
+import { Role } from "../../src/constants";
+import { Tenant } from "../../src/types";
+
+describe("GET /api/tenant/id", () => {
+    let connection: DataSource;
+    let jwt: ReturnType<typeof createJwtMock>;
+
+    beforeAll(async () => {
+        jwt = createJwtMock("http://localhost:5000");
+        connection = await AppDataSource.initialize();
+    });
+
+    beforeEach(async () => {
+        jwt.start();
+        await connection.dropDatabase();
+        await connection.synchronize();
+    });
+
+    afterEach(() => {
+        jwt.stop();
+    });
+
+    const tenantData = {
+        name: "Fudo Restaurant",
+        address: "Near Sivaji Nagar, Barshi",
+    };
+
+    describe("Given all fields", () => {
+        it("should returns the 200 status code", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.ADMIN,
+            });
+
+            const createTenantResponse = await request(app)
+                .post("/api/tenant/create")
+                .set("Cookie", [`accessToken=${adminToken}`])
+                .send(tenantData);
+
+            const getTenantResponse = await request(app)
+                .get(
+                    `/api/tenant/${
+                        (createTenantResponse.body.tenant as Tenant).id
+                    }`,
+                )
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(getTenantResponse.statusCode).toBe(200);
+        });
+
+        it("should returns the json status code", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.ADMIN,
+            });
+
+            const createTenantResponse = await request(app)
+                .post("/api/tenant/create")
+                .set("Cookie", [`accessToken=${adminToken}`])
+                .send(tenantData);
+
+            const getTenantResponse = await request(app)
+                .get(
+                    `/api/tenant/${
+                        (createTenantResponse.body.tenant as Tenant).id
+                    }`,
+                )
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(
+                (getTenantResponse.headers as Record<string, string>)[
+                    "content-type"
+                ],
+            ).toEqual(expect.stringContaining("json"));
+        });
+
+        it("should returns the tenant data", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.ADMIN,
+            });
+
+            const createTenantResponse = await request(app)
+                .post("/api/tenant/create")
+                .set("Cookie", [`accessToken=${adminToken}`])
+                .send(tenantData);
+
+            const getTenantResponse = await request(app)
+                .get(
+                    `/api/tenant/${
+                        (createTenantResponse.body.tenant as Tenant).id
+                    }`,
+                )
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(getTenantResponse.body.tenant as Tenant).toHaveProperty(
+                "id",
+            );
+            expect(getTenantResponse.body.tenant as Tenant).toHaveProperty(
+                "rating",
+            );
+            expect(getTenantResponse.body.tenant as Tenant).toHaveProperty(
+                "name",
+            );
+            expect(getTenantResponse.body.tenant as Tenant).toHaveProperty(
+                "address",
+            );
+        });
+
+        it("should returns the null tenant data if id is not found!", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.ADMIN,
+            });
+
+            const getTenantResponse = await request(app)
+                .get(`/api/tenant/90`)
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(getTenantResponse.body.tenant).toBeNull();
+        });
+
+        it("should returns the 403 status code if user is not admin", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.MANAGER,
+            });
+
+            const getTenantResponse = await request(app)
+                .get(`/api/tenant/9`)
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(getTenantResponse.statusCode).toBe(403);
+        });
+
+        it("should returns the 403 status code if id is not in params!", async () => {
+            const adminToken = jwt.token({
+                sub: "1",
+                role: Role.ADMIN,
+            });
+
+            const getTenantResponse = await request(app)
+                .get(`/api/tenant/eriuw`)
+                .set("Cookie", [`accessToken=${adminToken}`]);
+
+            expect(getTenantResponse.statusCode).toBe(400);
+        });
+    });
+});


### PR DESCRIPTION
## Description
This pull request introduces a new endpoint to retrieve a list of all tenants via a `GET` request. The endpoint is located at `api/tenant/:id`.

## Changes Made
- Added a new route for the `GET /api/tenant:id` endpoint.

## Response 

```json
  tenant : {
    "id" : 1,
    "name" : "Tenant 1",
    "address" : "address 1",
    "rating" : 7
  }
```

## Testing
✅ Manually tested the new endpoint to ensure it returns the expected list of tenants.
✅ New endpoint added and tested
✅ Follows the coding style and conventions of the project
✅ Commit messages are clear and descriptive