### PR TITLE
`ManyToOne` relationship for the `Tenant` entity  in the `User` entity

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -155,6 +155,7 @@ export default class AuthController {
                 email,
                 password: hashPassword,
                 role: Role.CUSTOMER,
+                tenant: null,
             });
         } catch (error) {
             return next(error);

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -207,8 +207,13 @@ export default class AuthController {
     async self(req: AuthRequest, res: Response, next: NextFunction) {
         const id = Number(req.auth.sub);
         try {
-            const user = await this.userService.findUserById(id);
-            return res.json({ user: new UserDto(user!) });
+            const user = (await this.userService.findWithRelation(id))[0];
+
+            if (!user) {
+                return next(createHttpError(400, "User not foune"));
+            }
+
+            return res.json({ user: new UserDto(user) });
         } catch (error) {
             return next(error);
         }

--- a/src/dtos/UserDto.ts
+++ b/src/dtos/UserDto.ts
@@ -1,15 +1,19 @@
 import { User } from "../entity";
+import { Tenant } from "../types";
+import TenantDto from "./TenantDto";
 
 export default class UserDto {
     id: number;
     fullName: string;
     email: string;
     role: string;
+    tenant: Tenant | null;
 
     constructor(user: User) {
         this.id = user.id;
         this.fullName = user.fullName;
         this.email = user.email;
         this.role = user.role;
+        this.tenant = user.tenant ? new TenantDto(user.tenant) : null;
     }
 }

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -2,9 +2,12 @@ import {
     Column,
     CreateDateColumn,
     Entity,
+    JoinColumn,
+    ManyToOne,
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from "typeorm";
+import Tenant from "./Tenant";
 
 @Entity({ name: "users" })
 export default class User {
@@ -22,6 +25,10 @@ export default class User {
 
     @Column()
     role: string;
+
+    @ManyToOne(() => Tenant, { nullable: true })
+    @JoinColumn({ name: "tenantId" })
+    tenant: Tenant;
 
     @UpdateDateColumn()
     updatedAt: number;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -4,7 +4,7 @@ import { UserData } from "../types";
 import { User } from "../entity";
 import { Repository } from "typeorm";
 import { Logger } from "winston";
-
+import { User as FullUser } from "../types";
 export default class UserService {
     constructor(
         private userRepository: Repository<User>,
@@ -58,6 +58,13 @@ export default class UserService {
         return await this.userRepository.findOne({ where: { id } });
     }
 
+    async findWithRelation(id: number) {
+        return await this.userRepository.find({
+            where: { id },
+            relations: ["tenant"],
+        });
+    }
+
     async deleteUserById(id: number) {
         return await this.userRepository.delete(id);
     }
@@ -78,5 +85,9 @@ export default class UserService {
             );
             throw error;
         }
+    }
+
+    async save(user: FullUser) {
+        await this.userRepository.save(user);
     }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export interface UserData {
     password: string;
     confirmPassword?: string;
     role?: string;
+    tenant: Tenant | null;
 }
 export interface SendOtpRequest extends Request {
     body: UserData;
@@ -90,4 +91,12 @@ export interface TenantData {
 
 export interface TenantRequest extends Request {
     body: TenantData;
+}
+
+export interface UpdateUserRequest extends Request {
+    body: {
+        fullName: string;
+        tenantId: string | null;
+        role: string;
+    };
 }


### PR DESCRIPTION
## Description
This pull request adds a `ManyToOne` relationship for the `Tenant` entity in the `User` entity. The goal is to establish an association between users and their corresponding tenants.

## Changes Made
- Added a new column `tenantId` to the `User` entity to establish a `ManyToOne` relationship with the `Tenant` entity.
- Updated the `User` entity to include the `@ManyToOne` decorator for the `tenant` property.
- Created a foreign key relationship between the `User` and `Tenant` tables in the database schema.

## Usage Example

```typescript
// Assuming you have an instance of User
const user = new User();

// Assuming you have an instance of Tenant
const tenant = new Tenant();

// Set the tenant for the user
user.tenant = tenant;

// Save the user entity
await userRepository.save(user);
```

## Testing
- Manually tested the relationship by creating and saving users with associated tenants.
- Verified that database queries return the expected results when fetching users with their associated tenants.

## Checklist
 ✅ ManyToOne relationship added and tested.
 ✅ Database schema updated with the new foreign key.
 ✅ Follows the coding style and conventions of the project.
 ✅ Commit messages are clear and descriptive.