### PR TITLE
Pull Request: Remove Admin Permission for Get All Tenants

### DIFF
--- a/src/routes/tenant.ts
+++ b/src/routes/tenant.ts
@@ -39,7 +39,6 @@ router.delete(
 
 router.get(
     "/",
-    [accessTokenMiddleware, canAccess([Role.ADMIN])],
     (req: Request, res: Response, next: NextFunction) =>
         tenantController.getAll(req, res, next) as unknown as RequestHandler,
 );

--- a/tests/tenant/getAll.test.ts
+++ b/tests/tenant/getAll.test.ts
@@ -31,27 +31,13 @@ describe("GET /api/tenant", () => {
 
     describe("Given all fields", () => {
         it("should returns the 200 status code", async () => {
-            const adminToken = jwt.token({
-                sub: "1",
-                role: Role.ADMIN,
-            });
-
-            const getTenantResponse = await request(app)
-                .get("/api/tenant")
-                .set("Cookie", [`accessToken=${adminToken}`]);
+            const getTenantResponse = await request(app).get("/api/tenant");
 
             expect(getTenantResponse.statusCode).toBe(200);
         });
 
         it("should returns json data", async () => {
-            const adminToken = jwt.token({
-                sub: "1",
-                role: Role.ADMIN,
-            });
-
-            const getTenantResponse = await request(app)
-                .get("/api/tenant")
-                .set("Cookie", [`accessToken=${adminToken}`]);
+            const getTenantResponse = await request(app).get("/api/tenant");
 
             expect(
                 (getTenantResponse.headers as Record<string, string>)[
@@ -71,24 +57,9 @@ describe("GET /api/tenant", () => {
                 .send(tenantData)
                 .set("Cookie", [`accessToken=${adminToken}`]);
 
-            const getTenantResponse = await request(app)
-                .get("/api/tenant")
-                .set("Cookie", [`accessToken=${adminToken}`]);
+            const getTenantResponse = await request(app).get("/api/tenant");
 
             expect(getTenantResponse.body.tenants).toHaveLength(1);
-        });
-
-        it("should return 403 status code if permission not allowed!", async () => {
-            const adminToken = jwt.token({
-                sub: "1",
-                role: Role.MANAGER,
-            });
-
-            const getTenantResponse = await request(app)
-                .get("/api/tenant")
-                .set("Cookie", [`accessToken=${adminToken}`]);
-
-            expect(getTenantResponse.statusCode).toBe(403);
         });
     });
 });


### PR DESCRIPTION
## Description
This pull request addresses the need to remove the admin permission requirement for accessing all tenants. Additionally, the associated access middleware has been removed to simplify the authentication and authorization process.

## Changes
- Removed admin permission requirement for the "Get All Tenants" functionality.
- Removed the access middleware responsible for checking admin permissions.

## Related Issues
Closes #<Issue Number>

## Checklist
- [ ✔️ ] Code has been tested locally and is working as expected.
- [ ✔️ ] The code follows the project's coding standards.
- [ ✔️ ] There are no unresolved merge conflicts.

## Testing Instructions
1. Clone this branch locally.
2. Run the application.
3. Verify that non-admin users can successfully access the "Get All Tenants" endpoint.

